### PR TITLE
Log error when exchanging token

### DIFF
--- a/githubauth.go
+++ b/githubauth.go
@@ -133,6 +133,7 @@ func (h *Handler) loginOk(ctx context.Context, w http.ResponseWriter, r *http.Re
 		tok, err := conf.Exchange(ctx, r.FormValue("code"))
 		if err != nil {
 			h.deleteCookie(w)
+			log.Println("Error exchanging cookie: ", err)
 			http.Error(w, "access forbidden", 401)
 			return ctx, false
 		}


### PR DESCRIPTION
Was having problems setting up github auth as it kept failing to exchange the code into an access token. This error was hiding useful info - namely that my client secret was invalid/incorrectly set up.

The actual error was clearly on my side but this at least will display that message somewhere (ie in the log).
